### PR TITLE
feat: reduce some code bloat by removing generics used for conversions

### DIFF
--- a/src/axis.rs
+++ b/src/axis.rs
@@ -1,6 +1,5 @@
 //! Coordinate axis
 
-use std::borrow::IntoCow;
 use std::string::CowString;
 
 use map;
@@ -68,10 +67,10 @@ impl Configure<Grid> for Properties {
     }
 }
 
-impl<S> Set<Label<S>> for Properties where S: IntoCow<'static, String, str> {
+impl Set<Label> for Properties {
     /// Attaches a label to the axis
-    fn set(&mut self, label: Label<S>) -> &mut Properties {
-        self.label = Some(label.0.into_cow());
+    fn set(&mut self, label: Label) -> &mut Properties {
+        self.label = Some(label.0);
         self
     }
 }

--- a/src/candlestick.rs
+++ b/src/candlestick.rs
@@ -1,6 +1,5 @@
 //! "Candlestick" plots
 
-use std::borrow::IntoCow;
 use std::string::CowString;
 
 use data::Matrix;
@@ -61,10 +60,10 @@ impl Set<Color> for Properties {
     }
 }
 
-impl<S> Set<Label<S>> for Properties where S: IntoCow<'static, String, str> {
+impl Set<Label> for Properties {
     /// Sets the legend label
-    fn set(&mut self, label: Label<S>) -> &mut Properties {
-        self.label = Some(label.0.into_cow());
+    fn set(&mut self, label: Label) -> &mut Properties {
+        self.label = Some(label.0);
         self
     }
 }

--- a/src/curve.rs
+++ b/src/curve.rs
@@ -1,6 +1,5 @@
 //! Simple "curve" like plots
 
-use std::borrow::IntoCow;
 use std::string::CowString;
 
 use {
@@ -95,10 +94,10 @@ impl Set<Color> for Properties {
     }
 }
 
-impl<S> Set<Label<S>> for Properties where S: IntoCow<'static, String, str> {
+impl Set<Label> for Properties {
     /// Sets the legend label
-    fn set(&mut self, label: Label<S>) -> &mut Properties {
-        self.label = Some(label.0.into_cow());
+    fn set(&mut self, label: Label) -> &mut Properties {
+        self.label = Some(label.0);
         self
     }
 }

--- a/src/errorbar.rs
+++ b/src/errorbar.rs
@@ -1,6 +1,5 @@
 //! Error bar plots
 
-use std::borrow::IntoCow;
 use std::string::CowString;
 
 use {
@@ -79,10 +78,10 @@ impl Set<Color> for Properties {
     }
 }
 
-impl<S> Set<Label<S>> for Properties where S: IntoCow<'static, String, str> {
+impl Set<Label> for Properties {
     /// Sets the legend label
-    fn set(&mut self, label: Label<S>) -> &mut Properties {
-        self.label = Some(label.0.into_cow());
+    fn set(&mut self, label: Label) -> &mut Properties {
+        self.label = Some(label.0);
         self
     }
 }

--- a/src/filledcurve.rs
+++ b/src/filledcurve.rs
@@ -1,6 +1,5 @@
 //! Filled curve plots
 
-use std::borrow::IntoCow;
 use std::string::CowString;
 
 use data::Matrix;
@@ -82,10 +81,10 @@ impl Set<Color> for Properties {
     }
 }
 
-impl<S> Set<Label<S>> for Properties where S: IntoCow<'static, String, str> {
+impl Set<Label> for Properties {
     /// Sets the legend label
-    fn set(&mut self, label: Label<S>) -> &mut Properties {
-        self.label = Some(label.0.into_cow());
+    fn set(&mut self, label: Label) -> &mut Properties {
+        self.label = Some(label.0);
         self
     }
 }

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,6 +1,5 @@
 //! Key (or legend)
 
-use std::borrow::IntoCow;
 use std::string::CowString;
 
 use traits::Set;
@@ -146,9 +145,9 @@ impl Set<Stacked> for Properties {
     }
 }
 
-impl<S> Set<Title<S>> for Properties where S: IntoCow<'static, String, str> {
-    fn set(&mut self, title: Title<S>) -> &mut Properties {
-        self.title = Some(title.0.into_cow());
+impl Set<Title> for Properties {
+    fn set(&mut self, title: Title) -> &mut Properties {
+        self.title = Some(title.0);
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,7 +357,6 @@
 #[macro_use]
 extern crate zip;
 
-use std::borrow::IntoCow;
 use std::io::{Command, File, IoResult, Process};
 use std::str;
 use std::string::CowString;
@@ -378,6 +377,7 @@ pub mod filledcurve;
 pub mod grid;
 pub mod key;
 pub mod prelude;
+pub mod proxy;
 pub mod traits;
 
 /// Plot container
@@ -582,10 +582,10 @@ impl Set<BoxWidth> for Figure {
     }
 }
 
-impl<S> Set<Font<S>> for Figure where S: IntoCow<'static, String, str> {
+impl Set<Font> for Figure {
     /// Changes the font
-    fn set(&mut self, font: Font<S>) -> &mut Figure {
-        self.font = Some(font.0.into_cow());
+    fn set(&mut self, font: Font) -> &mut Figure {
+        self.font = Some(font.0);
         self
     }
 }
@@ -635,10 +635,10 @@ impl Set<Terminal> for Figure {
     }
 }
 
-impl<S> Set<Title<S>> for Figure where S: IntoCow<'static, String, str> {
+impl Set<Title> for Figure {
     /// Sets the title
-    fn set(&mut self, title: Title<S>) -> &mut Figure {
-        self.title = Some(title.0.into_cow());
+    fn set(&mut self, title: Title) -> &mut Figure {
+        self.title = Some(title.0);
         self
     }
 }
@@ -648,8 +648,7 @@ impl<S> Set<Title<S>> for Figure where S: IntoCow<'static, String, str> {
 pub struct BoxWidth(pub f64);
 
 /// A font name
-#[derive(Copy)]
-pub struct Font<S: IntoCow<'static, String, str>>(pub S);
+pub struct Font(CowString<'static>);
 
 /// The size of a font
 #[derive(Copy)]
@@ -660,7 +659,7 @@ pub struct FontSize(pub f64);
 pub struct Key;
 
 /// Plot label
-pub struct Label<S: IntoCow<'static, String, str>>(pub S);
+pub struct Label(CowString<'static>);
 
 /// Width of the lines
 #[derive(Copy)]
@@ -699,7 +698,7 @@ pub struct TicLabels<P, L> {
 }
 
 /// Figure title
-pub struct Title<S: IntoCow<'static, String, str>>(pub S);
+pub struct Title(CowString<'static>);
 
 /// A pair of axes that define a coordinate system
 #[allow(missing_docs)]

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,18 +1,13 @@
 //! A collection of the most used traits, structs and enums
 
 pub use {
-    Axes, Axis, BoxWidth, Color, Figure, Font, FontSize, Grid, Key, Label, LineType, LineWidth,
-    Opacity, Output, PointSize, PointType, Range, Scale, Size, Terminal, TicLabels, Title,
+    Axes, Axis, BoxWidth, Color, Figure, FontSize, Grid, Key, LineType, LineWidth, Opacity, Output,
+    PointSize, PointType, Range, Scale, Size, Terminal, TicLabels,
 };
 pub use candlestick::Candlesticks;
-pub use curve::Curve::{
-    Dots, Impulses, Lines, LinesPoints, Points, Steps,
-};
-pub use errorbar::ErrorBar::{
-    XErrorBars, XErrorLines, YErrorBars, YErrorLines,
-};
+pub use curve::Curve::{Dots, Impulses, Lines, LinesPoints, Points, Steps};
+pub use errorbar::ErrorBar::{XErrorBars, XErrorLines, YErrorBars, YErrorLines};
 pub use filledcurve::FilledCurve;
-pub use key::{
-    Boxed, Horizontal, Justification, Order, Position, Stacked, Vertical,
-};
+pub use key::{Boxed, Horizontal, Justification, Order, Position, Stacked, Vertical};
+pub use proxy::{Font, Label, Title};
 pub use traits::{Configure, Plot, Set};

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1,0 +1,23 @@
+//! Generic constructors for newtypes
+
+#![allow(non_snake_case)]
+
+use std::borrow::IntoCow;
+
+/// Generic constructor for `Font`
+#[inline(always)]
+pub fn Font<S>(string: S) -> ::Font where S: IntoCow<'static, String, str> {
+    ::Font(string.into_cow())
+}
+
+/// Generic constructor for `Label`
+#[inline(always)]
+pub fn Label<S>(string: S) -> ::Label where S: IntoCow<'static, String, str> {
+    ::Label(string.into_cow())
+}
+
+/// Generic constructor for `Title`
+#[inline(always)]
+pub fn Title<S>(string: S) -> ::Title where S: IntoCow<'static, String, str> {
+    ::Title(string.into_cow())
+}


### PR DESCRIPTION
This changes the following newtypes:

- `Font`
- `Label`
- `Title`

from being generic `Label<S: IntoCow>(S)` to fully concrete newtypes
`Label(CowString)`. To avoid breaking existing code, proxy functions
(see `src/proxy.rs`)named exactly after the newtype constructors were added to
the prelude, these proxy functions take care of calling `into_cow()`.

Most of existing code will continue working. However, this is a
[breaking-change] because the newtypes can no longer be stored in `const` or
`static` variables.