### PR TITLE
Fix compile error when running cargo test.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,8 +385,6 @@ extern crate byteorder;
 extern crate cast;
 #[macro_use]
 extern crate itertools;
-#[cfg(test)]
-extern crate itertools_num;
 
 use std::borrow::Cow;
 use std::fs::File;


### PR DESCRIPTION
Minor change, just fixes a compile error when running tests.