### PR TITLE
Fix Appveyor/Travis builds.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     TARGET: x86_64-pc-windows-msvc
   matrix:
-    - RUST_VERSION: 1.6.0
+    - RUST_VERSION: 1.9.0
     - RUST_VERSION: beta
     - RUST_VERSION: nightly
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -499,7 +499,7 @@ impl Figure {
         for plot in &self.plots {
             let data = plot.data();
 
-            if data.bytes().len() == 0 {
+            if data.bytes().is_empty() {
                 continue;
             }
 
@@ -524,7 +524,7 @@ impl Figure {
             }
             s.push(' ');
 
-            s.push_str(&plot.script());
+            s.push_str(plot.script());
         }
 
         let mut buffer = s.into_bytes();
@@ -938,7 +938,7 @@ pub fn version() -> io::Result<(usize, usize, usize)> {
     let mut version = words.next().unwrap().split('.');
     let major = version.next().unwrap().parse().unwrap();
     let minor = version.next().unwrap().parse().unwrap();
-    let patchlevel = words.skip(1).next().unwrap().parse().unwrap();
+    let patchlevel = words.nth(1).unwrap().parse().unwrap();
 
     Ok((major, minor, patchlevel))
 }


### PR DESCRIPTION
Fixed clippy lint warnings and increased the minimum Rust version on appveyor to 1.9.0, as itertools 0.5 gives compile errors on earlier versions.