### PR TITLE
Fix Build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ environment:
   global:
     TARGET: x86_64-pc-windows-msvc
   matrix:
-    - RUST_VERSION: 1.6.0
+    - RUST_VERSION: 1.9.0
     - RUST_VERSION: beta
     - RUST_VERSION: nightly
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,10 +1,5 @@
 set -ex
 
 if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-  oldpath=$(pwd)
-  cd $HOME
-  git clone https://github.com/arcnmx/cargo-clippy
-  cd $HOME/cargo-clippy
-  cargo build --release
-  cd $oldpath
+  cargo install clippy
 fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -497,7 +497,7 @@ impl Figure {
         for plot in &self.plots {
             let data = plot.data();
 
-            if data.bytes().len() == 0 {
+            if data.bytes().is_empty() {
                 continue;
             }
 
@@ -522,7 +522,7 @@ impl Figure {
             }
             s.push(' ');
 
-            s.push_str(&plot.script());
+            s.push_str(plot.script());
         }
 
         let mut buffer = s.into_bytes();
@@ -936,7 +936,7 @@ pub fn version() -> io::Result<(usize, usize, usize)> {
     let mut version = words.next().unwrap().split('.');
     let major = version.next().unwrap().parse().unwrap();
     let minor = version.next().unwrap().parse().unwrap();
-    let patchlevel = words.skip(1).next().unwrap().parse().unwrap();
+    let patchlevel = words.nth(1).unwrap().parse().unwrap();
 
     Ok((major, minor, patchlevel))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,8 +385,6 @@ extern crate byteorder;
 extern crate cast;
 #[macro_use]
 extern crate itertools;
-#[cfg(test)]
-extern crate itertools_num;
 
 use std::borrow::Cow;
 use std::fs::File;


### PR DESCRIPTION
Fix a compile error when running tests, update minimum Rust version for appveyor (because 1.9.0 is needed to build itertools) and fixed Clippy warnings.